### PR TITLE
Fixed autofit issue (prototype.js conflict)

### DIFF
--- a/gmap3.js
+++ b/gmap3.js
@@ -1968,7 +1968,7 @@
       if (id in this._ids){
         for(n in this._ids[id].stored){
           stored = this._ids[id].stored[n];
-          for(k in stored){
+          for(k=0;k<stored.length;k++){
             obj = stored[k].obj;
             if (obj.getPosition){
               bounds.extend(obj.getPosition());


### PR DESCRIPTION
Changed for-loop in function autofit, to work correct with prototype running in legacy mode.

If prototype js is running, the array 'k' will be extended with 'each'. So the loop will run once more as it should.
This causes a fatal error ("obj is undefinded")
