### PR TITLE
Change to MarkerWithLabel for google.maps.Marker

### DIFF
--- a/gmap3.js
+++ b/gmap3.js
@@ -1242,7 +1242,13 @@
       } else {
         o.options.position = latLng;
         o.options.map = this._getMap(id);
-        result = new MarkerWithLabel(o.options); //using MarkerWithLabel official Google extsn of google.maps.Marker
+
+        if(typeof(MarkerWithLabel) === 'function') {
+           result = new MarkerWithLabel(o.options); //using MarkerWithLabel official Google extsn of google.maps.Marker
+        } else {
+           result = new google.maps.Marker(o.options);
+        }
+
         if ( todo[niw] ){
           oi = this._object(niw, todo[niw], ['open']);
           if ( (oi['open'] === undefined) || oi['open'] ) {
@@ -1309,7 +1315,13 @@
             o.options = options;
           }
           o.options.position = latLng;
-          marker = new MarkerWithLabel(o.options); //using MarkerWithLabel official Google extsn of google.maps.Marker
+
+          if(typeof(MarkerWithLabel) === 'function') {
+            marker = new MarkerWithLabel(o.options); //using MarkerWithLabel official Google extsn of google.maps.Marker
+          } else {
+            marker = new google.maps.Marker(o.options);
+          }
+
           result.push(marker);
           o.data = markers[k].data;
           o.tag = markers[k].tag;


### PR DESCRIPTION
I have used GMap3 for quite a while now, and on many of my projects, I have had the need to attach custom labels to the markers programatically. I have also witnessed this use case in forums and on StackOverflow and actually did find an Official Fix to this supplied by Google.

The solution is to use a MarkerWithLabel that extends the Google Maps JavaScript API V3 google.maps.Marker class. It wont break any existing functionalities in Google Maps or GMap3, only adds ability to use custom labels with arbitrary HTML or just plain text.

U can advise on this, but I think it would be very useful. Maybe the ability to fallback to the standard google.maps.Marker would make it much more useful in case someone doesn't want to use this?

Docs for this Extension are here : http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerwithlabel/1.0/docs/reference.html

Thanks,

Lutalo Joseph W.
