### PR TITLE
Fixes full property not passed for direct gets

### DIFF
--- a/gmap3.js
+++ b/gmap3.js
@@ -2476,7 +2476,7 @@
         $this.data("gmap3", gmap3);
       }
       if (list.length === 1 && (list[0] === "get" || isDirectGet(list[0]))){
-        results.push(gmap3.get(list[0] === "get" ? "map" : list[0].get, true));
+        results.push(gmap3.get(list[0] === "get" ? "map" : list[0].get, true, list[0].get.full));
       } else {
         gmap3._plan(list);
       }


### PR DESCRIPTION
In the example below, an array containing the Google marker objects is returned when it should return the "embedded" objects (containing id, tag, data, etc) instead.

```
var markers = $("#test").gmap3({
  get: {
    name: "marker",
    full: true,
    all: true
  }
});
```

This suggested change fixes this bug by passing the fourth parameter to the `get` function.

Thanks!
