### PR TITLE
Add Transit Layer to gmap3

### DIFF
--- a/dist/gmap3.js
+++ b/dist/gmap3.js
@@ -49,7 +49,7 @@ function initDefaults() {
       },
       classes: (function () {
         var r = {};
-        $.each("Map Marker InfoWindow Circle Rectangle OverlayView StreetViewPanorama KmlLayer TrafficLayer BicyclingLayer GroundOverlay StyledMapType ImageMapType".split(" "), function (_, k) {
+        $.each("Map Marker InfoWindow Circle Rectangle OverlayView StreetViewPanorama KmlLayer TrafficLayer TransitLayer BicyclingLayer GroundOverlay StyledMapType ImageMapType".split(" "), function (_, k) {
           r[k] = gm[k];
         });
         return r;
@@ -2136,6 +2136,20 @@ function Gmap3($this) {
       obj = new defaults.classes.TrafficLayer();
       obj.setMap(map);
       store.add(args, "trafficlayer", obj);
+    }
+    manageEnd(args, obj);
+  };
+
+  /**
+   * add a transit layer
+   **/
+  self.transitlayer = function (args) {
+    newMap();
+    var obj = store.get("transitlayer");
+    if (!obj) {
+      obj = new defaults.classes.TransitLayer();
+      obj.setMap(map);
+      store.add(args, "transitlayer", obj);
     }
     manageEnd(args, obj);
   };


### PR DESCRIPTION
This function allows to add a google.maps.TransitLayer

Usage:

Parameters: None

Example: In this example, transitlayer does not include options, or anything else, so the object can be reduce into a string

&lt;?php
$("#test").gmap3({ 
  map:{
    options:{ 
      center:[34.04924594193164, -118.24104309082031], 
      zoom: 13 
    }
  },
  transitlayer:{
  }
});
?&gt;